### PR TITLE
Adding atomic walkthroughs for Dataproc, Vertex AI, and Hail

### DIFF
--- a/dataproc/create a cluster.md
+++ b/dataproc/create a cluster.md
@@ -1,0 +1,14 @@
+From the GCP Console:
+1. Go to: [GCP Console](https://console.cloud.google.com)
+2. From the navigation menu at the top of the left sidebar: [View all products](https://console.cloud.google.com/products) -> [Analytics](https://console.cloud.google.com/products#analytics) -> [Dataproc](https://console.cloud.google.com/dataproc) ([docs](https://cloud.google.com/dataproc/docs)) – pin this so you can easily find it again
+4. From the sidebar: Jobs on Clusters -> [Clusters](https://console.cloud.google.com/dataproc/clusters)
+5. Click Create Cluster, then Cluster on Compute Engine. Follow the wizard, leaving the defaults in place if you don't have a reason to change them, and finish by clicking Create.
+
+---
+
+Alternatively, you can create clusters from the command line. The basic command is:
+```
+gcloud dataproc clusters create <cluster_name>
+```
+
+If it asks you if you'd like to enable the Dataproc API for your project, say Yes.

--- a/hail/hail-on-dataproc.DLC.md
+++ b/hail/hail-on-dataproc.DLC.md
@@ -1,0 +1,7 @@
+Running Hail on Dataproc
+
+Create a cluster as described in the "Dataproc setup"
+
+12/2/22 - Just before I left for a week off, I started organizing my notes on running Dataproc, Vertex AI, Hail, etc. into a hierarchical organization, with notebooks for each GCP technology and individual documents for each procedure. The idea was that a more complex walkthrough – one that integrated several of these technologies – would be able to point to the documentation for the invididual steps in the process, with branching logic, i.e. something like "if you need to clone a Github repo, see this document; if you need to retrieve something from Storage, see this other document; if you don't need either of those, please continue." This way, the amount of redundant documentation in complex walkthroughs could be kept to a minimum.
+
+**The next steps in this process are to do a complete walkthrough of getting Jina's burden testing notebook running on Dataproc in a JupyterLab notebook and documenting the process as described above, then adding these documents to the "general practices" repo.**

--- a/vertex-ai/create a vm.md
+++ b/vertex-ai/create a vm.md
@@ -1,0 +1,11 @@
+From the console:
+
+1. Go to: [GCP Console](https://console.cloud.google.com)
+2. From the navigation menu at the top of the left sidebar: [View all products](https://console.cloud.google.com/products) -> [Artificial Intelligence](https://console.cloud.google.com/products#artificial-intelligence) -> [Vertex AI](https://console.cloud.google.com/vertex-ai) ([docs](https://cloud.google.com/vertex-ai/docs)) – pin this so you can easily find it again
+4. From the sidebar: Tools -> [Workbench](https://console.cloud.google.com/vertex-ai/workbench/list/managed)
+5. From the menu at the top, click New Notebook and choose a basic programming environment (Python, R, etc.). In the dialog that opens, give the notebook a unique name and pick an appropriate region and zone. Click "Advanced Options" to choose operating system, machine type, disk size, memory size, etc. I used us-west1-b, Ubuntu 20.04, and an n1-highmem-4 machine, for example.
+6. Once created, click **OPEN JUPYTERLAB** next to the notebook.
+7. Update the system by running:
+	```
+	sudo apt update && sudo apt upgrade
+	```


### PR DESCRIPTION
Hi Paul,

Just before I left for a week off in early December, I started organizing my notes on running Dataproc, Vertex AI, Hail, etc. into a hierarchical organization, with directories for each GCP technology and individual documents for each procedure. The idea was that a more complex walkthrough – one that integrated several of these technologies – would be able to point to the documentation for the individual steps in the process, with branching logic, i.e. something like "if you need to clone a GitHub repo, see this document; if you need to retrieve something from Storage, see this other document; if you don't need either of those, please continue." This way, the amount of redundant documentation in complex walkthroughs could be kept to a minimum. Ideally, these would have actual links, like HTML, but I'm not sure how to do that yet in a GH repo.

The next steps in this process are to do a complete walkthrough of getting Jina's burden testing notebook running on Dataproc in a JupyterLab notebook and document the process as described above, then add these documents to the "general practices" repo. For now, I have added Vertex AI and Dataproc documentation. Your thoughts are welcomed.

Thanks,
Daniel